### PR TITLE
Improve getAllTasks() functionality 

### DIFF
--- a/src/main/java/com/obinstodo/todolist/controller/TaskController.java
+++ b/src/main/java/com/obinstodo/todolist/controller/TaskController.java
@@ -4,13 +4,11 @@ import com.obinstodo.todolist.model.Task;
 import com.obinstodo.todolist.service.TaskService;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @RestController
@@ -22,25 +20,12 @@ public class TaskController {
     private Task task;
     private final TaskService taskService;
 
-    @Autowired
     public TaskController(TaskService taskService) {
         this.taskService = taskService;
     }
 
     @GetMapping("/tasks")
     public ResponseEntity<List<Task>> getAllTasks() {
-        List<Task> tasks = new ArrayList<>();
-
-        return ResponseEntity.ok(tasks);
+        return ResponseEntity.ok(taskService.getAllTasks());
     }
-
-//    public void createTask(String title, String description, Date dueDate, boolean completed) {
-//        Task task = Task.builder()
-//                .title(title)
-//                .description(description)
-//                .dueDate(dueDate)
-//                .completed(completed)
-//                .build();
-//        setTask(task);
-//        }
 }

--- a/src/main/java/com/obinstodo/todolist/repository/InMemoryTaskRepository.java
+++ b/src/main/java/com/obinstodo/todolist/repository/InMemoryTaskRepository.java
@@ -17,8 +17,13 @@ public class InMemoryTaskRepository implements TaskRepository {
     }
 
     public void initializeTasks() {
+        Task task1 = new Task(1, "Description 1");
+        Task task2 = new Task(2, "Description 2");
+        Task task3 = new Task(3, "Description 3");
 
-        // Initialize tasks
+        tasks.add(task1);
+        tasks.add(task2);
+        tasks.add(task3);
     }
 
     @Override

--- a/src/main/java/com/obinstodo/todolist/service/DefaultTaskService.java
+++ b/src/main/java/com/obinstodo/todolist/service/DefaultTaskService.java
@@ -2,6 +2,7 @@ package com.obinstodo.todolist.service;
 
 import com.obinstodo.todolist.model.Task;
 import com.obinstodo.todolist.repository.TaskRepository;
+
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -9,23 +10,10 @@ import java.util.List;
 @Service
 public class DefaultTaskService implements TaskService {
   
-    private final List<Task> tasks;
     private final TaskRepository taskRepository;
 
-    public DefaultTaskService(List<Task> tasks, TaskRepository taskRepository) {
-        this.tasks = tasks;
+    public DefaultTaskService(TaskRepository taskRepository) {
         this.taskRepository = taskRepository;
-        initializeTasks();
-    }
-
-    private void initializeTasks() {
-        Task task1 = new Task(1, "Description 1");
-        Task task2 = new Task(2, "Description 2");
-        Task task3 = new Task(3, "Description 3");
-
-        tasks.add(task1);
-        tasks.add(task2);
-        tasks.add(task3);
     }
 
     @Override


### PR DESCRIPTION
- [ ] Remove the sample tasks from the getAllTasks() method in the TaskController. Instead, retrieve the tasks from the taskService.getAllTasks() method.
- [ ] Remove the Task task property from the TaskController class as it seems unnecessary based on the provided code.
- [ ] In the DefaultTaskService, remove the initializeTasks() method, as the task initialization logic should be handled by the TaskRepository implementation (InMemoryTaskRepository in this case). The DefaultTaskService should rely on the repository to provide the tasks.
- [ ] Ensure that the TaskRepository implementation (InMemoryTaskRepository) properly implements all the methods from the TaskRepository interface, including the initializeTasks() method.
- [ ] Consider using constructor injection for the DefaultTaskService in the TaskController instead of field injection. Modify the TaskController constructor to accept TaskService as a parameter and remove the @Autowired annotation
